### PR TITLE
Add Support for PHPUnit 11, Require Larave 12 & Optimize Code

### DIFF
--- a/app/Expectations.php
+++ b/app/Expectations.php
@@ -141,7 +141,7 @@ class Expectations
 
         $expectation = function (array $input, TestCase $test) use ($shouldPass, $with, $without) {
             foreach ($without as $field) {
-                unset($input[$field]);
+                Arr::forget($input, $field);
             }
 
             foreach ($with as $fied => $value) {

--- a/app/Expectations.php
+++ b/app/Expectations.php
@@ -3,6 +3,7 @@
 namespace Amerald\LaravelValidationTestkit;
 
 use Closure;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Tests\TestCase;
 
@@ -96,7 +97,7 @@ class Expectations
         }
         $field = preg_replace('/\.\*/', 0, $field);
 
-        $this->with[$field] = $value;
+        Arr::set($this->with, $field, $value);
 
         return $this;
     }

--- a/app/Expectations.php
+++ b/app/Expectations.php
@@ -57,8 +57,8 @@ class Expectations
      */
     private function buildExpectationName(string $modifier, string $field = null, $value = null)
     {
-        if (!Str::startsWith($this->expectationName, 'Request')) {
-            $this->expectationName = 'Request';
+        if (!Str::startsWith($this->expectationName, 'request')) {
+            $this->expectationName = 'request';
         }
 
         if (in_array($modifier, ['with', 'without'])) {

--- a/app/TestsRequests.php
+++ b/app/TestsRequests.php
@@ -13,7 +13,7 @@ trait TestsRequests
      *
      * @return string
      */
-    abstract protected static function request(): string;
+    abstract protected function request(): string;
 
     /**
      * Input to be validated.
@@ -22,7 +22,7 @@ trait TestsRequests
      *
      * @return array
      */
-    abstract protected static function input(): array;
+    abstract protected function input(): array;
 
     /**
      * Define validation expectations.
@@ -46,14 +46,14 @@ trait TestsRequests
      */
     public static function provideExpectations(): array
     {
-        $request = new Expectations(static::input());
+        $request = new Expectations();
         $expectations = [];
 
         /** @var array $expectation */
         foreach (static::expectations($request) as $expectation) {
             $name = array_keys($expectation)[0];
             $expectation = array_values($expectation)[0];
-            $expectations[$name] = [fn() => $expectation];
+            $expectations[$name] = $expectation;
         }
 
         return $expectations;
@@ -68,12 +68,8 @@ trait TestsRequests
     public function testRequest(Closure $expectation)
     {
         try {
-            $expectation = $expectation();
+            $expectation = $expectation($this->input(), $this);
             $input = $expectation->input();
-
-            array_walk($input, function (&$value) {
-                $value = $value instanceof Closure ? $value($this) : $value;
-            });
 
             $request = static::request();
             $request = new $request($input, $input);

--- a/app/TestsRequests.php
+++ b/app/TestsRequests.php
@@ -68,8 +68,14 @@ trait TestsRequests
     {
         try {
             $expectation = $expectation();
+            $input = $expectation->input();
+
+            array_walk($input, function (&$value) {
+                $value = $value instanceof Closure ? $value(isset($this->faker) ? $this->faker : null) : $value;
+            });
+
             $request = static::request();
-            $request = new $request($expectation->input(), $expectation->input());
+            $request = new $request($input, $input);
 
             $request->validate($request->rules());
             $passed = true;

--- a/app/TestsRequests.php
+++ b/app/TestsRequests.php
@@ -49,6 +49,7 @@ trait TestsRequests
         $request = new Expectations(static::input());
         $expectations = [];
 
+        /** @var array $expectation */
         foreach (static::expectations($request) as $expectation) {
             $name = array_keys($expectation)[0];
             $expectation = array_values($expectation)[0];
@@ -71,7 +72,7 @@ trait TestsRequests
             $input = $expectation->input();
 
             array_walk($input, function (&$value) {
-                $value = $value instanceof Closure ? $value(isset($this->faker) ? $this->faker : null) : $value;
+                $value = $value instanceof Closure ? $value($this) : $value;
             });
 
             $request = static::request();

--- a/composer.json
+++ b/composer.json
@@ -10,13 +10,13 @@
         }
     ],
     "require": {
-        "php": ">=7.1",
-        "laravel/framework": ">=5.5"
+        "php": "^8.3",
+        "laravel/framework": "^12.0"
     },
     "require-dev": {
         "mockery/mockery": "*",
         "orchestra/testbench": "*",
-        "phpunit/phpunit": "*"
+        "phpunit/phpunit": "^11.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
- Require Laravel 12
- Add support for PHPUnit 11
- Ensure that data providers are enclosed in closures to prevent code execution when PHPUnit loads all data providers as part of it's setup
- Allow working with factories/DB inside the `input()` method